### PR TITLE
Fix type hint for k_factor in NaiveBayes constructor

### DIFF
--- a/models/naive_bayes.py
+++ b/models/naive_bayes.py
@@ -10,7 +10,7 @@ from spacy.tokens import Token, Doc
 
 class NaiveBayes(MLAlgorithm):  # pragma: no cover
     def __init__(
-        self, dataset: Dataset, model_name="naive-bayes", variation_name=None, k_factor=1
+        self, dataset: Dataset, model_name="naive-bayes", variation_name=None, k_factor: float=1
     ) -> None:  # pragma: no cover
         if k_factor != 1:
             variation_name = f"add-k-{k_factor}_" + variation_name


### PR DESCRIPTION
This pull request fixes the type hint for the k_factor parameter in the NaiveBayes constructor. The k_factor parameter should be of type float, but it was incorrectly defined as a generic type. This fix ensures that the type hint is accurate and improves the code's readability and maintainability.